### PR TITLE
spatialdata 0.3.0

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   run:
     - anndata >=0.9.1
     - click
-    - dask-core >=2024.4.1,<2025
+    - dask-core >=2024.4.1,<=2024.11.2
     - dask-image
     - datashader
     - fsspec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "spatialdata" %}
-{% set version = "0.2.5" %}
-{% set python_min = "3.9" %}
+{% set version = "0.3.0" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -8,11 +8,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/spatialdata-{{ version }}.tar.gz
-  sha256: 4ed8f30347a524548ce54f5957383dd8165ac27ead1c02c68be322854556d17f
+  sha256: 9215dd5171ac9ac0eed01a265f43092c8bdb760f0b1e994795fa274c5c638611
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
@@ -20,16 +20,16 @@ requirements:
     - hatch-vcs
     - hatchling
     - pip
-    - python {{ python_min }}
+    - python {{ python_min }},<3.13
   run:
     - anndata >=0.9.1
     - click
     - dask-core >=2024.4.1,<2025
     - dask-image
     - datashader
-    - fsspec <=2023.6
+    - fsspec
     - geopandas >=0.14
-    - multiscale-spatial-image >=1.0.0,<2.0.0
+    - multiscale-spatial-image >=2.0.2
     - networkx
     - numba
     - numpy
@@ -37,7 +37,7 @@ requirements:
     - pandas
     - pooch
     - pyarrow
-    - python >={{ python_min }}
+    - python >={{ python_min }},<3.13
     - pytorch
     - rich
     - scikit-image
@@ -45,11 +45,10 @@ requirements:
     - shapely >=2.0.1
     - spatial-image >=1.1.0
     - typing-extensions >=4.8.0
-    - xarray >=2023.12.0,<2024.10.0
-    - xarray-datatree
+    - xarray >=2024.10.0
     - xarray-schema
     - xarray-spatial >=0.3.5
-    - zarr
+    - zarr <3
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Closes #12
Closes #14 

Blocked by https://github.com/conda-forge/multiscale-spatial-image-feedstock/pull/5

Local rerendering had no effect because recently done in #10. The `python_min` in the recipe overrides the `python_min` in `.ci_support/`.

Explanation of differences from [the 0.3.0 `pyproject.toml`](https://github.com/scverse/spatialdata/blob/v0.3.0/pyproject.toml):
* Upper bound of ome-zarr is due to a conda-forge/setuptools-scm problem that needs to be fixed (https://github.com/conda-forge/ome-zarr-feedstock/issues/24)
* Upper bound of `<2025` for dask-core is because the breaking change was introduced in 2025.1.0. There is no reason that I am aware of that spatialdata 0.3.0 shouldn't be compatible with the 2024.12 minor releases of dask