### PR TITLE
Remove upper bound on ome-zarr

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - networkx
     - numba >=0.55.0
     - numpy
-    - ome-zarr >=0.8.4,<0.10.3
+    - ome-zarr >=0.8.4
     - pandas
     - pooch
     - pyarrow


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

I had added the upper bound on ome-zarr due to an artifact of the conda-forge binary (https://github.com/conda-forge/spatialdata-feedstock/commit/c80af143751e5119851cc7afc5145946bab90139, https://github.com/conda-forge/spatialdata-feedstock/pull/17). Because the version wasn't specified correctly by setuptools-scm, `pip check` failed. This has known been fixed for the latest ome-zarr 0.11.1 (https://github.com/conda-forge/ome-zarr-feedstock/pull/26, https://github.com/conda-forge/ome-zarr-feedstock/issues/24#issuecomment-2956091458)

This PR removes the artificial upper bound. I didn't bump the build number. This is more for long-term maintenance than an immediate release. However, if any developer or user feels it would be useful to be able to use spatialdata 0.4.0 with ome-zarr 0.11, then I can bump the build number.

Local rerendering had no effect.