### PR TITLE
Restrict ome-zarr version range in meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - networkx
     - numba >=0.55.0
     - numpy
-    - ome-zarr >=0.12.2
+    - ome-zarr >=0.12.2,<0.14.0
     - pandas
     - pooch
     - pyarrow


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Spatialdata does not work with the latest ome-zarr version 0.14.0.

It fails with this error:
```
  File "/usr/local/lib/python3.12/site-packages/zarr/core/common.py", line 200, in parse_shapelike
    raise TypeError(msg)
TypeError: Expected an iterable of integers. Got ((1, 1, 1), (100,), (100,)) instead.
```
or
```
  File "/usr/local/lib/python3.12/site-packages/zarr/core/common.py", line 200, in parse_shapelike
    raise TypeError(msg)
TypeError: Expected an iterable of integers. Got ((3,), (256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 184), (256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 256, 184)) instead.
.
```

@pavanvidem found it when we were testing the spatialdata wrapper on Galaxy. ([here](https://github.com/galaxyproject/tools-iuc/pull/7455#issuecomment-4053612723))